### PR TITLE
Apply project spacing style to method calls and dereferences

### DIFF
--- a/lib/SecurityGate/Engine/Dependencies.pm
+++ b/lib/SecurityGate/Engine/Dependencies.pm
@@ -4,7 +4,6 @@ package SecurityGate::Engine::Dependencies {
     use Readonly;
     our $VERSION = '0.1.0';
     use Mojo::UserAgent;
-    use Mojo::JSON;
     use Exporter 'import';
     Readonly my $HTTP_OK => 200;
 
@@ -12,20 +11,20 @@ package SecurityGate::Engine::Dependencies {
     our @SEVERITIES = ("critical", "high", "medium", "low");
 
     sub new {
-        my ($class, $token, $repository, $severity_limits) = @_;
+        my (undef, $token, $repository, $severity_limits) = @_;
 
         my %severity_counts = map { $_ => 0 } @SEVERITIES;
 
         my $endpoint = "https://api.github.com/repos/$repository/dependabot/alerts";
-        my $userAgent = Mojo::UserAgent->new();
-        my $request = $userAgent->get($endpoint, {Authorization => "Bearer $token"})->result();
+        my $user_agent = Mojo::UserAgent -> new();
+        my $request = $user_agent -> get($endpoint, {Authorization => "Bearer $token"}) -> result();
 
-        if ($request->code() == $HTTP_OK) {
-            my $data = $request->json();
+        if ($request -> code() == $HTTP_OK) {
+            my $data = $request -> json();
 
             foreach my $alert (@{$data}) {
-                if ($alert->{state} eq "open") {
-                    my $severity = $alert->{security_vulnerability}->{severity};
+                if ($alert -> {state} eq "open") {
+                    my $severity = $alert -> {security_vulnerability} -> {severity};
                     $severity_counts{$severity}++;
                 }
             }
@@ -41,8 +40,8 @@ package SecurityGate::Engine::Dependencies {
             my $threshold_exceeded = 0;
 
             foreach my $severity (@SEVERITIES) {
-                if ($severity_counts{$severity} > $severity_limits->{$severity}) {
-                    print "[+] More than $severity_limits->{$severity} $severity security alerts found.\n";
+                if ($severity_counts{$severity} > $severity_limits -> {$severity}) {
+                    print "[+] More than $severity_limits -> {$severity} $severity security alerts found.\n";
                     $threshold_exceeded = 1;
                 }
             }
@@ -51,7 +50,7 @@ package SecurityGate::Engine::Dependencies {
         }
 
         else {
-            print "Error: Unable to fetch alerts. HTTP status code: " . $request->code() . "\n";
+            print "Error: Unable to fetch alerts. HTTP status code: " . $request -> code() . "\n";
             return 1;
         }
     }

--- a/security-gate.pl
+++ b/security-gate.pl
@@ -32,24 +32,23 @@ sub main {
         my $result = 0;
 
         my %alert_checks = (
-            'dependency-alerts' => $dependency_alerts ? sub { SecurityGate::Engine::Dependencies->new($token, $repository, \%severity_limits) } : undef,
-            'secret-alerts'     => $secret_alerts ? sub { SecurityGate::Engine::Secrets->new($token, $repository, \%severity_limits) } : undef,
-            'code-alerts'       => $code_alerts ? sub { SecurityGate::Engine::Code->new($token, $repository, \%severity_limits) } : undef
+            'dependency-alerts' => $dependency_alerts ? sub { SecurityGate::Engine::Dependencies -> new($token, $repository, \%severity_limits) } : undef,
+            'secret-alerts'     => $secret_alerts ? sub { SecurityGate::Engine::Secrets -> new($token, $repository, \%severity_limits) } : undef,
+            'code-alerts'       => $code_alerts ? sub { SecurityGate::Engine::Code -> new($token, $repository, \%severity_limits) } : undef
         );
 
         for my $check (grep { defined } values %alert_checks) {
-            $result += $check->();
+            $result += $check -> ();
         }
 
         return $result;
     }
 
     else {
-        print SecurityGate::Utils::Helper->new();
+        print SecurityGate::Utils::Helper -> new();
         return 1;
     }
 
-    return 0;
 }
 
 if ($ENV{TEST_MODE}) {


### PR DESCRIPTION
### Motivation
- Enforce the project style that requires spaces before and after the `->` operator for method calls and hash/array dereferences. 
- Make engine modules and the CLI entrypoint consistent and easier to read. 
- Eliminate leftover unused imports and normalize constructors to avoid unused variables. 

### Description
- Apply spacing around `->` across `security-gate.pl` and `lib/SecurityGate/Engine/{Code,Dependencies,Secrets}.pm` to match the style guide. 
- Rename local variables like `$userAgent` to `$user_agent` and update constructors to `my (undef, $token, $repository, $severity_limits) = @_`. 
- Remove unused `Mojo::JSON` imports and replace literal `200` checks with the `Readonly` `$HTTP_OK` constant where appropriate. 

### Testing
- No automated tests were executed for this style-only change. 
- `perlcritic` was attempted previously but was not available in the environment so that check could not be run. 
- Changes were validated via repository diffs and file previews (`git diff`, `nl`) to confirm formatting updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eacb35508832baf68477993ce60b9)