### PR TITLE
Clarify alert request variable names and normalize spacing around `->`

### DIFF
--- a/lib/SecurityGate/Engine/Dependencies.pm
+++ b/lib/SecurityGate/Engine/Dependencies.pm
@@ -15,14 +15,14 @@ package SecurityGate::Engine::Dependencies {
 
         my %severity_counts = map { $_ => 0 } @SEVERITIES;
 
-        my $endpoint = "https://api.github.com/repos/$repository/dependabot/alerts";
+        my $alerts_endpoint = "https://api.github.com/repos/$repository/dependabot/alerts";
         my $user_agent = Mojo::UserAgent -> new();
-        my $request = $user_agent -> get($endpoint, {Authorization => "Bearer $token"}) -> result();
+        my $alerts_request = $user_agent -> get($alerts_endpoint, {Authorization => "Bearer $token"}) -> result();
 
-        if ($request -> code() == $HTTP_OK) {
-            my $data = $request -> json();
+        if ($alerts_request -> code() == $HTTP_OK) {
+            my $alerts_data = $alerts_request -> json();
 
-            foreach my $alert (@{$data}) {
+            foreach my $alert (@{$alerts_data}) {
                 if ($alert -> {state} eq "open") {
                     my $severity = $alert -> {security_vulnerability} -> {severity};
                     $severity_counts{$severity}++;
@@ -50,7 +50,7 @@ package SecurityGate::Engine::Dependencies {
         }
 
         else {
-            print "Error: Unable to fetch alerts. HTTP status code: " . $request -> code() . "\n";
+            print "Error: Unable to fetch alerts. HTTP status code: " . $alerts_request -> code() . "\n";
             return 1;
         }
     }

--- a/tests/helper-output.t
+++ b/tests/helper-output.t
@@ -9,7 +9,7 @@ use lib '../lib';
 use SecurityGate::Utils::Helper;
 
 subtest 'Helper output' => sub {
-    my $helper_output = SecurityGate::Utils::Helper->new();
+    my $helper_output = SecurityGate::Utils::Helper -> new();
 
     like($helper_output, qr/Security\ Gate\ v0\.1\.0/xms, 'Helper output contains version');
     like($helper_output, qr/-t,\ --token/xms, 'Helper output contains token option');

--- a/tests/open-code-scanning-alerts-exceeding-limits.t
+++ b/tests/open-code-scanning-alerts-exceeding-limits.t
@@ -43,7 +43,7 @@ subtest 'Open code scanning alerts exceeding limits' => sub {
 
     my $mock_response = Mojo::UserAgent -> set_mock_response(Test::MockObject -> new);
     $mock_response -> set_always('code', $HTTP_OK);
-    $mock_response->set_always('json', [
+    $mock_response -> set_always('json', [
         { state => 'open', rule => { security_severity_level => 'high' } },
         { state => 'open', rule => { security_severity_level => 'high' } },
         { state => 'open', rule => { security_severity_level => 'medium' } },


### PR DESCRIPTION
### Motivation

- Enforce consistent spacing around the Perl dereference operator `->` across the project for readability and style conformity.
- Replace ambiguous variable names related to alert API requests with clearer, intent-revealing identifiers.
- Make purely local refactors that do not change runtime logic or external behavior.

### Description

- Rename request-related variables in `lib/SecurityGate/Engine/Dependencies.pm` from ` $endpoint`/`$request`/`$data` to ` $alerts_endpoint`/`$alerts_request`/`$alerts_data` and update usages accordingly.
- Rename request-related variables in `lib/SecurityGate/Engine/Secrets.pm` from ` $endpoint`/`$request`/`$data` to ` $alerts_endpoint`/`$alerts_request`/`$alerts_data`, rename loop/local variable ` $detail` to ` $alert_detail`, and tidy related dereferences.
- Normalize spacing around `->` in updated test files (`tests/helper-output.t` and `tests/open-code-scanning-alerts-exceeding-limits.t`) and ensure consistent dereference syntax (e.g., `@{$alerts_data}`).
- Minor whitespace cleanup in `Secrets.pm` to maintain consistent formatting while preserving behavior.

### Testing

- Ran `rg -n "\S->|->\S" *.pl lib tests` to check for any remaining `->` occurrences without spaces and found no matches.
- Inspected modified files with `nl` to verify variable renames and `->` spacing were applied as intended.
- No automated test suite (`prove -l tests`) was executed in this change set.
- Changes were committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636798f474832b8a819236b96189b5)