### PR TITLE
Add total open secret scanning alerts output

### DIFF
--- a/lib/SecurityGate/Component/SecretAlerts.pm
+++ b/lib/SecurityGate/Component/SecretAlerts.pm
@@ -45,6 +45,8 @@ package SecurityGate::Component::SecretAlerts {
             }
         }
 
+        print "\n[!] Total of open secret scanning alerts: $open_alerts\n\n";
+
         foreach my $alert_detail (@alert_details) {
             print "[-] Alert " . $alert_detail -> {alert_number} . " found in the following locations:\n";
 


### PR DESCRIPTION
### Motivation
- Make secret scanning output consistent with other alert components by reporting the total number of open alerts before listing details.

### Description
- Insert a `print` statement in `lib/SecurityGate/Component/SecretAlerts.pm` to emit the total open secret scanning alerts (`$open_alerts`) prior to iterating and printing each alert's locations.
- No other logic or behavior was changed; the function still returns `1` when threshold is exceeded and `0` otherwise.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697290be72b8832b9331536039cf0eb8)