### PR TITLE
Apply style guide formatting across Perl sources

### DIFF
--- a/lib/SecurityGate/Component/CodeAlerts.pm
+++ b/lib/SecurityGate/Component/CodeAlerts.pm
@@ -13,16 +13,21 @@ package SecurityGate::Component::CodeAlerts {
         my $alerts_endpoint = "https://api.github.com/repos/$repository/code-scanning/alerts";
 
         my $user_agent = Mojo::UserAgent -> new();
-        my $alerts_request = $user_agent -> get($alerts_endpoint, {Authorization => "Bearer $token"}) -> result();
+        my $alerts_request = $user_agent -> get(
+            $alerts_endpoint,
+            {Authorization => "Bearer $token"}
+        ) -> result();
 
         if ($alerts_request -> code() != $HTTP_OK) {
-            print "Error: Unable to fetch code scanning alerts. HTTP status code: " . $alerts_request -> code() . "\n";
+            print "Error: Unable to fetch code scanning alerts. HTTP status code: "
+                . $alerts_request -> code()
+                . "\n";
             return 1;
         }
 
         my $alerts_data = $alerts_request -> json();
         my $open_alerts = 0;
-        my %severity_counts = map {$_ => 0} keys %{$severity_limits};
+        my %severity_counts = map { $_ => 0 } keys %{$severity_limits};
 
         foreach my $alert (@{$alerts_data}) {
             if ($alert -> {state} eq "open") {
@@ -51,7 +56,8 @@ package SecurityGate::Component::CodeAlerts {
 
         foreach my $severity (keys %severity_counts) {
             if ($severity_counts{$severity} > $severity_limits -> {$severity}) {
-                print "[+] More than $severity_limits -> {$severity} $severity code scanning alerts found.\n";
+                print "[+] More than $severity_limits -> {$severity} "
+                    . "$severity code scanning alerts found.\n";
                 $threshold_exceeded = 1;
             }
         }

--- a/lib/SecurityGate/Component/DependencyAlerts.pm
+++ b/lib/SecurityGate/Component/DependencyAlerts.pm
@@ -19,10 +19,15 @@ package SecurityGate::Component::DependencyAlerts {
 
         my $alerts_endpoint = "https://api.github.com/repos/$repository/dependabot/alerts";
         my $user_agent = Mojo::UserAgent -> new();
-        my $alerts_request = $user_agent -> get($alerts_endpoint, {Authorization => "Bearer $token"}) -> result();
+        my $alerts_request = $user_agent -> get(
+            $alerts_endpoint,
+            {Authorization => "Bearer $token"}
+        ) -> result();
 
         if ($alerts_request -> code() != $HTTP_OK) {
-            print "Error: Unable to fetch alerts. HTTP status code: " . $alerts_request -> code() . "\n";
+            print "Error: Unable to fetch alerts. HTTP status code: "
+                . $alerts_request -> code()
+                . "\n";
             return 1;
         }
 
@@ -47,7 +52,8 @@ package SecurityGate::Component::DependencyAlerts {
 
         foreach my $severity (@SEVERITIES) {
             if ($severity_counts{$severity} > $severity_limits -> {$severity}) {
-                print "[+] More than $severity_limits -> {$severity} $severity security alerts found.\n";
+                print "[+] More than $severity_limits -> {$severity} "
+                    . "$severity security alerts found.\n";
                 $threshold_exceeded = 1;
             }
         }

--- a/lib/SecurityGate/Component/SecretAlerts.pm
+++ b/lib/SecurityGate/Component/SecretAlerts.pm
@@ -13,10 +13,15 @@ package SecurityGate::Component::SecretAlerts {
 
         my $alerts_endpoint = "https://api.github.com/repos/$repository/secret-scanning/alerts";
         my $user_agent = Mojo::UserAgent -> new();
-        my $alerts_request = $user_agent -> get($alerts_endpoint, {Authorization => "Bearer $token"}) -> result();
+        my $alerts_request = $user_agent -> get(
+            $alerts_endpoint,
+            {Authorization => "Bearer $token"}
+        ) -> result();
 
         if ($alerts_request -> code() != $HTTP_OK) {
-            print "Error: Unable to fetch secret scanning alerts. HTTP status code: " . $alerts_request -> code() . "\n";
+            print "Error: Unable to fetch secret scanning alerts. HTTP status code: "
+                . $alerts_request -> code()
+                . "\n";
             return 1;
         }
 
@@ -28,11 +33,14 @@ package SecurityGate::Component::SecretAlerts {
             if ($alert -> {state} eq "open") {
                 $open_alerts++;
 
-                my $locations_endpoint = "https://api.github.com/repos/$repository/secret-scanning/alerts/" . $alert -> {number} . "/locations";
+                my $locations_endpoint = "https://api.github.com/repos/$repository/secret-scanning/alerts/"
+                    . $alert -> {number}
+                    . "/locations";
 
-                my $locations_request = $user_agent -> get($locations_endpoint, {
-                    Authorization => "Bearer $token"
-                }) -> result();
+                my $locations_request = $user_agent -> get(
+                    $locations_endpoint,
+                    {Authorization => "Bearer $token"}
+                ) -> result();
 
                 if ($locations_request -> code() == $HTTP_OK) {
                     my $locations = $locations_request -> json();

--- a/lib/SecurityGate/Network/AlertNetwork.pm
+++ b/lib/SecurityGate/Network/AlertNetwork.pm
@@ -12,15 +12,33 @@ package SecurityGate::Network::AlertNetwork {
         my @checks;
 
         if ($alert_options -> {dependency_alerts}) {
-            push @checks, sub { SecurityGate::Component::DependencyAlerts -> new($token, $repository, $severity_limits) };
+            push @checks, sub {
+                return SecurityGate::Component::DependencyAlerts -> new(
+                    $token,
+                    $repository,
+                    $severity_limits
+                );
+            };
         }
 
         if ($alert_options -> {secret_alerts}) {
-            push @checks, sub { SecurityGate::Component::SecretAlerts -> new($token, $repository, $severity_limits) };
+            push @checks, sub {
+                return SecurityGate::Component::SecretAlerts -> new(
+                    $token,
+                    $repository,
+                    $severity_limits
+                );
+            };
         }
 
         if ($alert_options -> {code_alerts}) {
-            push @checks, sub { SecurityGate::Component::CodeAlerts -> new($token, $repository, $severity_limits) };
+            push @checks, sub {
+                return SecurityGate::Component::CodeAlerts -> new(
+                    $token,
+                    $repository,
+                    $severity_limits
+                );
+            };
         }
 
         my $result = 0;

--- a/security-gate.pl
+++ b/security-gate.pl
@@ -12,8 +12,8 @@ use SecurityGate::Utils::Helper;
 
 sub main {
     my ($token, $repository, $dependency_alerts, $secret_alerts, $code_alerts);
-    
-    my %severity_limits = map {$_ => 0} @SEVERITIES;
+
+    my %severity_limits = map { $_ => 0 } @SEVERITIES;
 
     Getopt::Long::GetOptions(
         "t|token=s"         => \$token,
@@ -34,7 +34,12 @@ sub main {
             code_alerts       => $code_alerts
         );
 
-        my $result = SecurityGate::Network::AlertNetwork -> new($token, $repository, \%severity_limits, \%alert_options);
+        my $result = SecurityGate::Network::AlertNetwork -> new(
+            $token,
+            $repository,
+            \%severity_limits,
+            \%alert_options
+        );
         return $result;
     }
 
@@ -46,6 +51,6 @@ if ($ENV{TEST_MODE}) {
     main();
 }
 
-if (! $ENV{TEST_MODE}) {
+if (!$ENV{TEST_MODE}) {
     exit main();
 }

--- a/tests/code-api-request-error.t
+++ b/tests/code-api-request-error.t
@@ -19,7 +19,7 @@ use Capture::Tiny qw(capture_stdout);
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -41,7 +41,9 @@ use SecurityGate::Component::CodeAlerts;
 subtest 'API request error' => sub {
     plan tests => 2;
 
-    my $mock_response = Mojo::UserAgent -> set_mock_response(Test::MockObject -> new);
+    my $mock_response = Mojo::UserAgent -> set_mock_response(
+        Test::MockObject -> new
+    );
     $mock_response -> set_always('code', $HTTP_UNAUTHORIZED);
 
     my %severity_limits = (
@@ -56,11 +58,13 @@ subtest 'API request error' => sub {
     my $status_code = qr/\s HTTP \s status \s code: \s $HTTP_UNAUTHORIZED/xms;
     my $full_error_pattern = qr/$error_message$status_code/xms;
 
-    stdout_like(
-        sub { $result = SecurityGate::Component::CodeAlerts -> new('test_token', 'test_repo', \%severity_limits) },
-        $full_error_pattern,
-        'Correct error message for API request failure'
-    );
+    stdout_like(sub {
+        $result = SecurityGate::Component::CodeAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, $full_error_pattern, 'Correct error message for API request failure');
 
     is($result, 1, 'Returns 1 when API request fails');
 };

--- a/tests/dependencies-api-error-handling.t
+++ b/tests/dependencies-api-error-handling.t
@@ -18,7 +18,7 @@ use Test::Output;
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -52,7 +52,11 @@ subtest 'API error handling' => sub {
     );
 
     is(
-        SecurityGate::Component::DependencyAlerts -> new('invalid_token', 'test_repo', \%severity_limits),
+        SecurityGate::Component::DependencyAlerts -> new(
+            'invalid_token',
+            'test_repo',
+            \%severity_limits
+        ),
         1,
         'Returns 1 when API request fails'
     );

--- a/tests/dependencies-severity-counting.t
+++ b/tests/dependencies-severity-counting.t
@@ -18,7 +18,7 @@ use Test::Output;
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -44,10 +44,10 @@ subtest 'Severity counting' => sub {
     Mojo::UserAgent -> set_mock_response($mock_response);
     $mock_response -> set_always('code', $HTTP_OK);
     $mock_response -> set_always('json', [
-        { state => 'open', security_vulnerability => { severity => 'high' } },
-        { state => 'open', security_vulnerability => { severity => 'critical' } },
-        { state => 'open', security_vulnerability => { severity => 'medium' } },
-        { state => 'closed', security_vulnerability => { severity => 'low' } },
+        {state => 'open', security_vulnerability => {severity => 'high'}},
+        {state => 'open', security_vulnerability => {severity => 'critical'}},
+        {state => 'open', security_vulnerability => {severity => 'medium'}},
+        {state => 'closed', security_vulnerability => {severity => 'low'}},
     ]);
 
     my %severity_limits = (
@@ -57,11 +57,14 @@ subtest 'Severity counting' => sub {
         low      => 0
     );
 
-    stdout_like(
-        sub { SecurityGate::Component::DependencyAlerts -> new('test_token', 'test_repo', \%severity_limits) },
-        qr/critical:\ 1.*high:\ 1.*medium:\ 1.*low:\ 0/xsm,
-        'Severity counts are correct'
-    );
+    stdout_like(sub {
+        SecurityGate::Component::DependencyAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, qr/critical:\ 1.*high:\ 1.*medium:\ 1.*low:\ 0/xsm,
+        'Severity counts are correct');
 };
 
 done_testing();

--- a/tests/dependencies-threshold-checking.t
+++ b/tests/dependencies-threshold-checking.t
@@ -18,7 +18,7 @@ use Test::Output;
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -44,8 +44,8 @@ subtest 'Threshold checking' => sub {
     Mojo::UserAgent -> set_mock_response($mock_response);
     $mock_response -> set_always('code', $HTTP_OK);
     $mock_response -> set_always('json', [
-        { state => 'open', security_vulnerability => { severity => 'critical' } },
-        { state => 'open', security_vulnerability => { severity => 'critical' } },
+        {state => 'open', security_vulnerability => {severity => 'critical'}},
+        {state => 'open', security_vulnerability => {severity => 'critical'}},
     ]);
 
     my %severity_limits_exceeded = (
@@ -63,13 +63,21 @@ subtest 'Threshold checking' => sub {
     );
 
     is(
-        SecurityGate::Component::DependencyAlerts -> new('test_token', 'test_repo', \%severity_limits_exceeded),
+        SecurityGate::Component::DependencyAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits_exceeded
+        ),
         1,
         'Returns 1 when threshold is exceeded'
     );
 
     is(
-        SecurityGate::Component::DependencyAlerts -> new('test_token', 'test_repo', \%severity_limits_not_exceeded),
+        SecurityGate::Component::DependencyAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits_not_exceeded
+        ),
         0,
         'Returns 0 when threshold is not exceeded'
     );

--- a/tests/helper-output.t
+++ b/tests/helper-output.t
@@ -11,12 +11,36 @@ use SecurityGate::Utils::Helper;
 subtest 'Helper output' => sub {
     my $helper_output = SecurityGate::Utils::Helper -> new();
 
-    like($helper_output, qr/Security\ Gate\ v0\.1\.0/xms, 'Helper output contains version');
-    like($helper_output, qr/-t,\ --token/xms, 'Helper output contains token option');
-    like($helper_output, qr/-r,\ --repo/xms, 'Helper output contains repo option');
-    like($helper_output, qr/--dependency-alerts/xms, 'Helper output contains dependency alerts option');
-    like($helper_output, qr/--secret-alerts/xms, 'Helper output contains secret scanning alerts option');
-    like($helper_output, qr/--code-alerts/xms, 'Helper output contains code scanning alerts option');
+    like(
+        $helper_output,
+        qr/Security\ Gate\ v0\.1\.0/xms,
+        'Helper output contains version'
+    );
+    like(
+        $helper_output,
+        qr/-t,\ --token/xms,
+        'Helper output contains token option'
+    );
+    like(
+        $helper_output,
+        qr/-r,\ --repo/xms,
+        'Helper output contains repo option'
+    );
+    like(
+        $helper_output,
+        qr/--dependency-alerts/xms,
+        'Helper output contains dependency alerts option'
+    );
+    like(
+        $helper_output,
+        qr/--secret-alerts/xms,
+        'Helper output contains secret scanning alerts option'
+    );
+    like(
+        $helper_output,
+        qr/--code-alerts/xms,
+        'Helper output contains code scanning alerts option'
+    );
 };
 
 done_testing();

--- a/tests/no-open-code-scanning-alerts.t
+++ b/tests/no-open-code-scanning-alerts.t
@@ -19,7 +19,7 @@ use Capture::Tiny qw(capture_stdout);
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -41,7 +41,9 @@ use SecurityGate::Component::CodeAlerts;
 subtest 'No open code scanning alerts' => sub {
     plan tests => 2;
 
-    my $mock_response = Mojo::UserAgent -> set_mock_response(Test::MockObject -> new);
+    my $mock_response = Mojo::UserAgent -> set_mock_response(
+        Test::MockObject -> new
+    );
     $mock_response -> set_always('code', $HTTP_OK);
     $mock_response -> set_always('json', []);
 
@@ -54,11 +56,13 @@ subtest 'No open code scanning alerts' => sub {
 
     my $result;
     my $total_pattern = qr/\[!\] \s Total \s of \s open \s code \s scanning \s alerts: \s 0/xms;
-    stdout_like(
-        sub { $result = SecurityGate::Component::CodeAlerts -> new('test_token', 'test_repo', \%severity_limits) },
-        $total_pattern,
-        'Correct output for no open alerts'
-    );
+    stdout_like(sub {
+        $result = SecurityGate::Component::CodeAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, $total_pattern, 'Correct output for no open alerts');
 
     is($result, 0, 'Returns 0 when no open alerts are found');
 };

--- a/tests/no-open-secret-scanning-alerts.t
+++ b/tests/no-open-secret-scanning-alerts.t
@@ -25,7 +25,7 @@ BEGIN {
     my $locations_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -61,8 +61,8 @@ subtest 'No open secret scanning alerts' => sub {
     plan tests => 2;
 
     MockMojoUserAgent::setup_mock_response($HTTP_OK, [
-        { state => 'closed' },
-        { state => 'closed' },
+        {state => 'closed'},
+        {state => 'closed'},
     ]);
 
     my %severity_limits = (
@@ -81,11 +81,13 @@ subtest 'No open secret scanning alerts' => sub {
 
     my $expected_output = qr/$expected_output_part1.*$expected_output_part2/xsm;
 
-    stdout_like(
-        sub { $result = SecurityGate::Component::SecretAlerts -> new('test_token', 'test_repo', \%severity_limits) },
-        $expected_output,
-        'Correct output for no open alerts'
-    );
+    stdout_like(sub {
+        $result = SecurityGate::Component::SecretAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, $expected_output, 'Correct output for no open alerts');
 
     is($result, 0, 'Returns 0 when no open alerts are found');
 };

--- a/tests/open-code-scanning-alerts-exceeding-limits.t
+++ b/tests/open-code-scanning-alerts-exceeding-limits.t
@@ -19,7 +19,7 @@ use Capture::Tiny qw(capture_stdout);
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -41,12 +41,14 @@ use SecurityGate::Component::CodeAlerts;
 subtest 'Open code scanning alerts exceeding limits' => sub {
     plan tests => 3;
 
-    my $mock_response = Mojo::UserAgent -> set_mock_response(Test::MockObject -> new);
+    my $mock_response = Mojo::UserAgent -> set_mock_response(
+        Test::MockObject -> new
+    );
     $mock_response -> set_always('code', $HTTP_OK);
     $mock_response -> set_always('json', [
-        { state => 'open', rule => { security_severity_level => 'high' } },
-        { state => 'open', rule => { security_severity_level => 'high' } },
-        { state => 'open', rule => { security_severity_level => 'medium' } },
+        {state => 'open', rule => {security_severity_level => 'high'}},
+        {state => 'open', rule => {security_severity_level => 'high'}},
+        {state => 'open', rule => {security_severity_level => 'medium'}},
     ]);
 
     my %severity_limits = (
@@ -58,14 +60,24 @@ subtest 'Open code scanning alerts exceeding limits' => sub {
 
     my ($output, $result);
     $output = capture_stdout {
-        $result = SecurityGate::Component::CodeAlerts -> new('test_token', 'test_repo', \%severity_limits);
+        $result = SecurityGate::Component::CodeAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
     };
 
-    like($output, qr/\[!\] \s Total \s of \s open \s code \s scanning \s alerts: \s 3/xms,
-         'Output contains correct total alerts');
+    like(
+        $output,
+        qr/\[!\] \s Total \s of \s open \s code \s scanning \s alerts: \s 3/xms,
+        'Output contains correct total alerts'
+    );
 
-    like($output, qr/\[\+\] \s More \s than \s \d+ \s \w+ \s code \s scanning \s alerts \s found/xms,
-         'Output contains correct severity alert count');
+    like(
+        $output,
+        qr/\[\+\] \s More \s than \s \d+ \s \w+ \s code \s scanning \s alerts \s found/xms,
+        'Output contains correct severity alert count'
+    );
 
     is($result, 1, 'Returns 1 when open alerts exceed limits');
 };

--- a/tests/open-code-scanning-alerts-within-limits.t
+++ b/tests/open-code-scanning-alerts-within-limits.t
@@ -19,7 +19,7 @@ use Capture::Tiny qw(capture_stdout);
     my $mock_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -41,11 +41,13 @@ use SecurityGate::Component::CodeAlerts;
 subtest 'Open code scanning alerts within limits' => sub {
     plan tests => 2;
 
-    my $mock_response = Mojo::UserAgent -> set_mock_response(Test::MockObject -> new);
+    my $mock_response = Mojo::UserAgent -> set_mock_response(
+        Test::MockObject -> new
+    );
     $mock_response -> set_always('code', $HTTP_OK);
     $mock_response -> set_always('json', [
-        { state => 'open', rule => { severity => 'high' } },
-        { state => 'open', rule => { severity => 'medium' } },
+        {state => 'open', rule => {severity => 'high'}},
+        {state => 'open', rule => {severity => 'medium'}},
     ]);
 
     my %severity_limits = (
@@ -60,11 +62,13 @@ subtest 'Open code scanning alerts within limits' => sub {
     my $severity_pattern = qr/(?:\[-\] \s (?:low|medium|high|critical): \s \d+\s*)+/xms;
     my $full_pattern = qr/$total_pattern.*$severity_pattern/xms;
 
-    stdout_like(
-        sub { $result = SecurityGate::Component::CodeAlerts -> new('test_token', 'test_repo', \%severity_limits) },
-        $full_pattern,
-        'Correct output for open alerts within limits'
-    );
+    stdout_like(sub {
+        $result = SecurityGate::Component::CodeAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, $full_pattern, 'Correct output for open alerts within limits');
 
     is($result, 0, 'Returns 0 when open alerts are within limits');
 };

--- a/tests/open-secret-scanning-alerts-within-limits.t
+++ b/tests/open-secret-scanning-alerts-within-limits.t
@@ -25,7 +25,7 @@ BEGIN {
     my $locations_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -61,11 +61,11 @@ subtest 'Open secret scanning alerts within limits' => sub {
     plan tests => 2;
 
     MockMojoUserAgent::setup_mock_response($HTTP_OK, [
-        { state => 'open', number => 1 },
+        {state => 'open', number => 1},
     ]);
 
     MockMojoUserAgent::setup_locations_response($HTTP_OK, [
-        { details => { path => 'file.txt', start_line => 10 } },
+        {details => {path => 'file.txt', start_line => 10}},
     ]);
 
     my %severity_limits = (
@@ -86,11 +86,13 @@ subtest 'Open secret scanning alerts within limits' => sub {
 
     my $expected_output = qr/$expected_output_part1.*$expected_output_part2.*$expected_output_part3.*$expected_output_part4/xsm;
 
-    stdout_like(
-        sub { $result = SecurityGate::Component::SecretAlerts -> new('test_token', 'test_repo', \%severity_limits) },
-        $expected_output,
-        'Correct output for open alerts within limit'
-    );
+    stdout_like(sub {
+        $result = SecurityGate::Component::SecretAlerts -> new(
+            'test_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, $expected_output, 'Correct output for open alerts within limit');
 
     is($result, 0, 'Returns 0 when open alerts are within limit');
 };

--- a/tests/secrets-api-error-handling.t
+++ b/tests/secrets-api-error-handling.t
@@ -25,7 +25,7 @@ BEGIN {
     my $locations_response;
 
     sub new {
-        my $class = shift;
+        my ($class) = @_;
         return Test::MockObject -> new -> mock('get', sub {
             my ($self, $url, $headers) = @_;
             return Test::MockObject -> new -> mock('result', sub {
@@ -74,11 +74,13 @@ subtest 'API error handling' => sub {
     my $expected_error_output_part2 = qr/\ HTTP\ status\ code:\ $HTTP_UNAUTHORIZED/xms;
     my $expected_error_output = qr/$expected_error_output_part1.*$expected_error_output_part2/xms;
 
-    stdout_like(
-        sub { $result = SecurityGate::Component::SecretAlerts -> new('invalid_token', 'test_repo', \%severity_limits) },
-        $expected_error_output,
-        'Correct error message for API failure'
-    );
+    stdout_like(sub {
+        $result = SecurityGate::Component::SecretAlerts -> new(
+            'invalid_token',
+            'test_repo',
+            \%severity_limits
+        );
+    }, $expected_error_output, 'Correct error message for API failure');
 
     is($result, 1, 'Returns 1 when API request fails');
 };


### PR DESCRIPTION
### Motivation
- Align the CLI, network and component code with the project's Perl style guide to improve readability and consistency. 
- Make test mocks and fixtures clearer and avoid subtle stack/parameter handling issues in test packages. 

### Description
- Reflowed long function calls and request invocations to use multi-line argument formatting (e.g. `Mojo::UserAgent->get(...)` calls split across lines) and normalized `map` spacing and hash literal formatting. 
- Replaced several single-expression anonymous pushes with explicit block subs that `return` component constructors in `SecurityGate::Network::AlertNetwork`. 
- Normalized string concatenation and print formatting for error messages to improve line length and readability. 
- Updated test mock constructors to unpack `@_` as `my ($class) = @_` instead of using `shift`, cleaned up inline hash/array literals, and replaced compact single-line test blocks with multi-line invocations for `stdout_like`/captured calls. 
- Minor whitespace/style fixes in `security-gate.pl` (map spacing and argument formatting) and standardized the `if (!$ENV{TEST_MODE})` check formatting. 

### Testing
- No automated test suite was executed as part of this change (no test runner was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981cbc8ee70832ba3be7e500f1203e0)